### PR TITLE
Dev conda release test container

### DIFF
--- a/.devcontainer/conda-release/Dockerfile
+++ b/.devcontainer/conda-release/Dockerfile
@@ -1,0 +1,29 @@
+FROM mambaorg/micromamba:debian12-slim
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    git \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/conda-release-env
+SHELL [ "/bin/bash", "--login", "-c" ]
+RUN micromamba shell init --shell=bash --root-prefix=~/micromamba
+COPY environment.yaml environment.yaml
+
+RUN micromamba create -y -f environment.yaml \
+    && micromamba clean --all --yes
+
+WORKDIR /polsarpro-dev
+COPY README.md CHANGELOG.md LICENSE mkdocs.yml ./
+
+RUN echo "micromamba activate psp" >> ~/.bashrc \
+    && echo "alias conda='micromamba'" >> ~/.bashrc \
+    && mkdir -p ~/.local/share/jupyter/kernels
+
+ENV PYTHONNOUSERSITE=1
+
+CMD ["/bin/sh", "-c", "while sleep 1000; do :; done"]

--- a/.devcontainer/conda-release/Dockerfile
+++ b/.devcontainer/conda-release/Dockerfile
@@ -1,29 +1,5 @@
-FROM mambaorg/micromamba:debian12-slim
-
-USER root
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    git \
-    procps \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp/conda-release-env
-SHELL [ "/bin/bash", "--login", "-c" ]
-RUN micromamba shell init --shell=bash --root-prefix=~/micromamba
-COPY environment.yaml environment.yaml
-
-RUN micromamba create -y -f environment.yaml \
-    && micromamba clean --all --yes
+FROM condaforge/miniforge3:latest
 
 WORKDIR /polsarpro-dev
-COPY README.md CHANGELOG.md LICENSE mkdocs.yml ./
-
-RUN echo "micromamba activate psp" >> ~/.bashrc \
-    && echo "alias conda='micromamba'" >> ~/.bashrc \
-    && mkdir -p ~/.local/share/jupyter/kernels
-
-ENV PYTHONNOUSERSITE=1
 
 CMD ["/bin/sh", "-c", "while sleep 1000; do :; done"]

--- a/.devcontainer/conda-release/Dockerfile.dockerignore
+++ b/.devcontainer/conda-release/Dockerfile.dockerignore
@@ -1,0 +1,8 @@
+*
+
+!.devcontainer/conda-release/Dockerfile
+!environment.yaml
+!README.md
+!CHANGELOG.md
+!LICENSE
+!mkdocs.yml

--- a/.devcontainer/conda-release/Dockerfile.dockerignore
+++ b/.devcontainer/conda-release/Dockerfile.dockerignore
@@ -1,8 +1,3 @@
 *
 
-!.devcontainer/conda-release/Dockerfile
-!environment.yaml
-!README.md
-!CHANGELOG.md
-!LICENSE
-!mkdocs.yml
+!Dockerfile

--- a/.devcontainer/conda-release/README.md
+++ b/.devcontainer/conda-release/README.md
@@ -2,7 +2,7 @@
 
 This container is for testing the conda-forge package as an installed user would see it.
 
-It starts from a plain Miniforge image with only the base conda environment. It bind-mounts the local `README.md`, `data/`, `docs/`, `notebooks/`, and `tests/` into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
+It starts from a plain Miniforge image with only the base conda environment. It bind-mounts this README as `/polsarpro-dev/README.md` and the local `data/`, `docs/`, `notebooks/`, and `tests/` folders into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
 
 After opening the devcontainer, follow the main README conda-forge install flow:
 

--- a/.devcontainer/conda-release/README.md
+++ b/.devcontainer/conda-release/README.md
@@ -2,12 +2,14 @@
 
 This container is for testing the conda-forge package as an installed user would see it.
 
-It bind-mounts the local `data/`, `docs/`, `notebooks/`, and `tests/` folders into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
+It starts from a plain Miniforge image with only the base conda environment. It bind-mounts the local `data/`, `docs/`, `notebooks/`, and `tests/` folders into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
 
-After opening the devcontainer, install the released package manually:
+After opening the devcontainer, follow the main README conda-forge install flow:
 
 ```sh
-conda install -c conda-forge polsarpro
+conda create -n polsarpro
+conda activate polsarpro
+conda install conda-forge::polsarpro
 ```
 
 Then run tests from `/polsarpro-dev`:

--- a/.devcontainer/conda-release/README.md
+++ b/.devcontainer/conda-release/README.md
@@ -2,7 +2,7 @@
 
 This container is for testing the conda-forge package as an installed user would see it.
 
-It starts from a plain Miniforge image with only the base conda environment. It bind-mounts the local `data/`, `docs/`, `notebooks/`, and `tests/` folders into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
+It starts from a plain Miniforge image with only the base conda environment. It bind-mounts the local `README.md`, `data/`, `docs/`, `notebooks/`, and `tests/` into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
 
 After opening the devcontainer, follow the main README conda-forge install flow:
 

--- a/.devcontainer/conda-release/README.md
+++ b/.devcontainer/conda-release/README.md
@@ -1,0 +1,17 @@
+# Conda release-test devcontainer
+
+This container is for testing the conda-forge package as an installed user would see it.
+
+It bind-mounts the local `data/`, `docs/`, `notebooks/`, and `tests/` folders into `/polsarpro-dev`, but it does not copy or mount the `polsarpro/` source package and does not set `PYTHONPATH`.
+
+After opening the devcontainer, install the released package manually:
+
+```sh
+conda install -c conda-forge polsarpro
+```
+
+Then run tests from `/polsarpro-dev`:
+
+```sh
+pytest tests
+```

--- a/.devcontainer/conda-release/devcontainer.json
+++ b/.devcontainer/conda-release/devcontainer.json
@@ -18,8 +18,8 @@
       ],
       "settings": {
         "isort.importStrategy": "fromEnvironment",
-        "isort.interpreter": ["/root/micromamba/envs/psp/bin/python"],
-        "python.defaultInterpreterPath": "/root/micromamba/envs/psp/bin/python",
+        "isort.interpreter": ["/opt/conda/bin/python"],
+        "python.defaultInterpreterPath": "/opt/conda/bin/python",
         "git.ignoreLimitWarning": true,
         "[python]": {
           "editor.defaultFormatter": "ms-python.black-formatter",

--- a/.devcontainer/conda-release/devcontainer.json
+++ b/.devcontainer/conda-release/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "polsarpro-conda-release",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "polsarpro-conda-release",
+  "mounts": [
+    "source=${localEnv:HOME}/.codex-devcontainers/${localWorkspaceFolderBasename}-conda-release,target=/root/.codex,type=bind",
+    "source=${localEnv:HOME}/codex-contexts/${localWorkspaceFolderBasename},target=/codex-context,type=bind"
+  ],
+  "workspaceFolder": "/polsarpro-dev",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.isort",
+        "ms-python.black-formatter",
+        "ms-toolsai.jupyter",
+        "njpwerner.autodocstring"
+      ],
+      "settings": {
+        "isort.importStrategy": "fromEnvironment",
+        "isort.interpreter": ["/root/micromamba/envs/psp/bin/python"],
+        "python.defaultInterpreterPath": "/root/micromamba/envs/psp/bin/python",
+        "git.ignoreLimitWarning": true,
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.black-formatter",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/conda-release/docker-compose.yml
+++ b/.devcontainer/conda-release/docker-compose.yml
@@ -5,8 +5,8 @@ services:
 
   polsarpro-conda-release:
     build:
-      context: ../..
-      dockerfile: .devcontainer/conda-release/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     volumes:
       - ../../data:/polsarpro-dev/data
       - ../../docs:/polsarpro-dev/docs

--- a/.devcontainer/conda-release/docker-compose.yml
+++ b/.devcontainer/conda-release/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: "3.7"
+
+services:
+
+  polsarpro-conda-release:
+    build:
+      context: ../..
+      dockerfile: .devcontainer/conda-release/Dockerfile
+    volumes:
+      - ../../data:/polsarpro-dev/data
+      - ../../docs:/polsarpro-dev/docs
+      - ../../notebooks:/polsarpro-dev/notebooks
+      - ../../tests:/polsarpro-dev/tests
+      - ${HOME}/data:/data
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.devcontainer/conda-release/docker-compose.yml
+++ b/.devcontainer/conda-release/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ../../README.md:/polsarpro-dev/README.md:ro
+      - ./README.md:/polsarpro-dev/README.md:ro
       - ../../data:/polsarpro-dev/data
       - ../../docs:/polsarpro-dev/docs
       - ../../notebooks:/polsarpro-dev/notebooks

--- a/.devcontainer/conda-release/docker-compose.yml
+++ b/.devcontainer/conda-release/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
+      - ../../README.md:/polsarpro-dev/README.md:ro
       - ../../data:/polsarpro-dev/data
       - ../../docs:/polsarpro-dev/docs
       - ../../notebooks:/polsarpro-dev/notebooks


### PR DESCRIPTION
Add a test environment for conda releases:
- custom devcontainer handles test container in vscode
- dockerfile installs minimal miniforge image
- docker-compose mounts local folders required for tests
- local README describes testing environment and install instructions